### PR TITLE
Fix for "all" command on bash v4

### DIFF
--- a/sash.sh
+++ b/sash.sh
@@ -46,7 +46,7 @@ function sash {
   fi
   local instances_data
   local default_user=${SASH_DEFAULT_USER:-ubuntu}
-  read -a instances_data <<< ${instance}
+  read -a instances_data <<< $(echo ${instance} | xargs)
 
   eval $(_get_data pems 0 ${instances_data[@]})
   eval $(_get_data ips 1 ${instances_data[@]})


### PR DESCRIPTION
The "all" command is not working on bash v4.  It looks like the reading of the instances_data into an array from instance is not reading all lines, only one of them.   Using xargs solves the problem as it puts everything into a single line. 